### PR TITLE
hotfix: prevent same-day data leakage in historical stats

### DIFF
--- a/scripts/prepare_racecard.py
+++ b/scripts/prepare_racecard.py
@@ -367,10 +367,10 @@ class RacecardPreparer:
                 self.logger.warning(f"Missing horse_id for runner: {runner.get('name', 'Unknown')}")
                 return None
             
-            # Get historical records
-            horse_records = self.horse_history.get(horse_id, [])
-            jockey_records = self.jockey_history.get(jockey_id, [])
-            trainer_records = self.trainer_history.get(trainer_id, [])
+            # Get historical records (filter to exclude current date to prevent data leakage)
+            horse_records = [r for r in self.horse_history.get(horse_id, []) if r['date'] < self.target_date]
+            jockey_records = [r for r in self.jockey_history.get(jockey_id, []) if r['date'] < self.target_date]
+            trainer_records = [r for r in self.trainer_history.get(trainer_id, []) if r['date'] < self.target_date]
             
             # Basic race information
             course = course_name


### PR DESCRIPTION
- Fixed encode_incremental.py: filter historical records to exclude current race date (r['date'] < race_date)
- Fixed prepare_racecard.py: filter historical records to exclude current target date (r['date'] < target_date)
- Removed daily_horse_history tracking from encode_incremental.py as it's no longer needed with proper date filtering
- Updated _encode_single_record() function signature to remove unused daily history parameters
- Ensures lifetime and 14-day stats for horses, jockeys, and trainers never include same-day race data
- Prevents data leakage when encoding features for historical training data and live predictions

This hotfix ensures temporal integrity by guaranteeing that feature engineering only uses information available before the current race/prediction date.